### PR TITLE
Configurable image for service-serving-cert-signer

### DIFF
--- a/install/openshift-service-cert-signer-operator/install.yaml
+++ b/install/openshift-service-cert-signer-operator/install.yaml
@@ -64,7 +64,7 @@ objects:
         serviceAccountName: openshift-service-cert-signer-operator
         containers:
         - name: operator
-          image: openshift/origin-service-serving-cert-signer:v3.11
+          image: ${IMAGE}
           imagePullPolicy: ${OPENSHIFT_PULL_POLICY}
           command: ["service-serving-cert-signer", "operator"]
           args:

--- a/pkg/oc/clusterup/manifests/bindata.go
+++ b/pkg/oc/clusterup/manifests/bindata.go
@@ -17839,7 +17839,7 @@ objects:
         serviceAccountName: openshift-service-cert-signer-operator
         containers:
         - name: operator
-          image: openshift/origin-service-serving-cert-signer:v3.11
+          image: ${IMAGE}
           imagePullPolicy: ${OPENSHIFT_PULL_POLICY}
           command: ["service-serving-cert-signer", "operator"]
           args:
@@ -17873,7 +17873,7 @@ objects:
     name: instance
   spec:
     managementState: Managed
-    imagePullSpec: openshift/origin-service-serving-cert-signer:v3.11
+    imagePullSpec: ${IMAGE}
     version: 3.10.0
     logging:
       level: 4

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -33573,7 +33573,7 @@ objects:
         serviceAccountName: openshift-service-cert-signer-operator
         containers:
         - name: operator
-          image: openshift/origin-service-serving-cert-signer:v3.11
+          image: ${IMAGE}
           imagePullPolicy: ${OPENSHIFT_PULL_POLICY}
           command: ["service-serving-cert-signer", "operator"]
           args:
@@ -33607,7 +33607,7 @@ objects:
     name: instance
   spec:
     managementState: Managed
-    imagePullSpec: openshift/origin-service-serving-cert-signer:v3.11
+    imagePullSpec: ${IMAGE}
     version: 3.10.0
     logging:
       level: 4


### PR DESCRIPTION
Configurable image for service-serving-cert-signer when using "oc cluster up" command with "--image" command line parameter.

Refer to:

1. https://github.com/openshift/origin/issues/28339
1. https://github.com/openshift/origin/issues/20888
1. https://github.com/openshift/origin/issues/21148
1. https://github.com/openshift/origin/pull/20314

Building oc command line tool only:

```bash
hack/env make build WHAT=cmd/oc
```

The build "oc" command line tool should be located at "_output/local/bin/linux/amd64/oc"